### PR TITLE
Fix HTMLMediaElement.srcObject warning in Chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,15 +87,7 @@ var attach = module.exports = function(stream, opts, callback) {
     el = el || document.createElement(elType);
 
     // attach the stream
-    if (URL && URL.createObjectURL) {
-      el.src = URL.createObjectURL(stream);
-    }
-    else if (el.srcObject) {
-      el.srcObject = stream;
-    }
-    else if (el.mozSrcObject) {
-      el.mozSrcObject = stream;
-    }
+    el.srcObject = stream;
 
     if (autoplay === undefined || autoplay) {
       el.setAttribute('autoplay', '');

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ var extend = require('cog/extend');
 
 **/
 var attach = module.exports = function(stream, opts, callback) {
-  var URL = typeof window != 'undefined' && window.URL;
   var pinst;
 
   if (typeof opts == 'function') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtc-attach",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Attach a media stream to an existing or new media element (basically attachMediaStream with support for rtc.io plugins)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
More info:
[Deprecation] URL.createObjectURL with media streams is deprecated and will be removed in M68, around July 2018. Please use HTMLMediaElement.srcObject instead. See https://www.chromestatus.com/features/5618491470118912 for more details.